### PR TITLE
[Bugfix] Fitbit adjustments

### DIFF
--- a/config/fitbit_constants.py
+++ b/config/fitbit_constants.py
@@ -18,8 +18,8 @@ TIME_SERIES_TYPES = {
 }
 
 INTRA_TIME_SERIES_TYPES = {
-    'activities/calories': {'type':'float', 'interval':'1min'},
-    'activities/steps': {'type':'+int', 'interval':'1min'},
-    'activities/distance': {'type':'float', 'interval':'1min'},
-    'activities/heart': {'type':'float', 'interval':'1sec'},
+    'activities/calories': {'type': 'float', 'interval': '1min'},
+    'activities/steps': {'type': '+int', 'interval': '1min'},
+    'activities/distance': {'type': 'float', 'interval': '1min'},
+    'activities/heart': {'type': 'float', 'interval': '1sec'},
 }

--- a/config/fitbit_constants.py
+++ b/config/fitbit_constants.py
@@ -3,9 +3,6 @@ TIME_SERIES_TYPES = {
     'activities/caloriesBMR': 'float',
     'activities/steps': '+int',
     'activities/distance': 'float',
-    # may not work in some devices
-    #    'activities/floors': '+int',
-    #    'activities/elevation': 'float',
     'activities/minutesSedentary': '+int',
     'activities/minutesLightlyActive': '+int',
     'activities/minutesFairlyActive': '+int',

--- a/database/fitbit_models.py
+++ b/database/fitbit_models.py
@@ -21,6 +21,7 @@ class FitbitCredentials(models.Model):
             delete_fitbit_records_trigger(self)
         except:
             pass
+
         super(FitbitCredentials, self).delete()
 
 
@@ -52,14 +53,18 @@ class FitbitRecord(models.Model):
     class Meta:
         unique_together = ('participant', 'date',)
 
+
 for data_stream, data_stream_type in TIME_SERIES_TYPES.items():
     data_stream = data_stream.replace('/', '_')
     if data_stream_type == '+int':
-        FitbitRecord.add_to_class(data_stream, models.PositiveIntegerField(blank=True, null=True))
+        FitbitRecord.add_to_class(
+            data_stream, models.PositiveIntegerField(blank=True, null=True))
     elif data_stream_type == 'float':
-        FitbitRecord.add_to_class(data_stream, models.FloatField(blank=True, null=True))
+        FitbitRecord.add_to_class(
+            data_stream, models.FloatField(blank=True, null=True))
     elif data_stream_type == 'json':
-        FitbitRecord.add_to_class(data_stream, models.TextField(blank=True, null=True))
+        FitbitRecord.add_to_class(
+            data_stream, models.TextField(blank=True, null=True))
 
 
 class FitbitIntradayRecord(models.Model):
@@ -74,11 +79,15 @@ class FitbitIntradayRecord(models.Model):
     class Meta:
         unique_together = ('participant', 'date',)
 
+
 for data_stream, data_stream_type in INTRA_TIME_SERIES_TYPES.items():
     data_stream = data_stream.replace('/', '_')
     if data_stream_type == '+int':
-        FitbitIntradayRecord.add_to_class(data_stream, models.PositiveIntegerField(blank=True, null=True))
+        FitbitIntradayRecord.add_to_class(
+            data_stream, models.PositiveIntegerField(blank=True, null=True))
     elif data_stream_type == 'float':
-        FitbitIntradayRecord.add_to_class(data_stream, models.FloatField(blank=True, null=True))
+        FitbitIntradayRecord.add_to_class(
+            data_stream, models.FloatField(blank=True, null=True))
     elif data_stream_type == 'json':
-        FitbitIntradayRecord.add_to_class(data_stream, models.TextField(blank=True, null=True))
+        FitbitIntradayRecord.add_to_class(
+            data_stream, models.TextField(blank=True, null=True))

--- a/database/fitbit_models.py
+++ b/database/fitbit_models.py
@@ -80,8 +80,9 @@ class FitbitIntradayRecord(models.Model):
         unique_together = ('participant', 'date',)
 
 
-for data_stream, data_stream_type in INTRA_TIME_SERIES_TYPES.items():
+for data_stream, data_stream_config in INTRA_TIME_SERIES_TYPES.items():
     data_stream = data_stream.replace('/', '_')
+    data_stream_type = data_stream_config['type']
     if data_stream_type == '+int':
         FitbitIntradayRecord.add_to_class(
             data_stream, models.PositiveIntegerField(blank=True, null=True))

--- a/database/fitbit_models.py
+++ b/database/fitbit_models.py
@@ -4,39 +4,61 @@ from database.user_models import Participant
 from config.fitbit_constants import TIME_SERIES_TYPES, INTRA_TIME_SERIES_TYPES
 
 
+
 class FitbitCredentials(models.Model):
-    user = models.OneToOneField(Participant, on_delete=models.CASCADE)
+    participant = models.OneToOneField(Participant, on_delete=models.CASCADE)
     refresh_token = models.TextField()
     access_token = models.TextField()
 
+    def delete(self):
+        # import here to avoid import-loop
+        from libs.fitbit import delete_fitbit_records_trigger
 
-class FitbitRecord(models.Model):
-    user = models.ForeignKey(Participant, on_delete=models.CASCADE)
-    last_updated = models.DateTimeField()
+        try:
+            delete_fitbit_records_trigger(self)
+        except:
+            pass
+        super(FitbitCredentials, self).delete()
+
+
+class FitbitInfo(models.Model):
+    participant = models.ForeignKey(Participant, on_delete=models.CASCADE)
+    date = models.DateTimeField()
 
     devices = models.TextField()
     friends = models.TextField()
     friends_leaderboard = models.TextField()
 
-for k, type_str in TIME_SERIES_TYPES.items():
-    k = k.replace('/', '_')
-    if type_str == '+int':
-        FitbitRecord.add_to_class(k, models.PositiveIntegerField(blank=True, null=True))
-    elif type_str == 'float':
-        FitbitRecord.add_to_class(k, models.FloatField(blank=True, null=True))
-    elif type_str == 'json':
-        FitbitRecord.add_to_class(k, models.TextField(blank=True, null=True))
+
+class FitbitRecord(models.Model):
+    participant = models.ForeignKey(Participant, on_delete=models.CASCADE)
+    date = models.DateTimeField()
+
+    class Meta:
+        unique_together = ('participant', 'date',)
+
+for data_stream, data_stream_type in TIME_SERIES_TYPES.items():
+    data_stream = data_stream.replace('/', '_')
+    if data_stream_type == '+int':
+        FitbitRecord.add_to_class(data_stream, models.PositiveIntegerField(blank=True, null=True))
+    elif data_stream_type == 'float':
+        FitbitRecord.add_to_class(data_stream, models.FloatField(blank=True, null=True))
+    elif data_stream_type == 'json':
+        FitbitRecord.add_to_class(data_stream, models.TextField(blank=True, null=True))
 
 
 class FitbitIntradayRecord(models.Model):
-    user = models.ForeignKey(Participant, on_delete=models.CASCADE)
-    last_updated = models.DateTimeField()
+    participant = models.ForeignKey(Participant, on_delete=models.CASCADE)
+    date = models.DateTimeField()
 
-for k, type_str in INTRA_TIME_SERIES_TYPES.items():
-    k = k.replace('/', '_')
-    if type_str == '+int':
-        FitbitIntradayRecord.add_to_class(k, models.PositiveIntegerField(blank=True, null=True))
-    elif type_str == 'float':
-        FitbitIntradayRecord.add_to_class(k, models.FloatField(blank=True, null=True))
-    elif type_str == 'json':
-        FitbitIntradayRecord.add_to_class(k, models.TextField(blank=True, null=True))
+    class Meta:
+        unique_together = ('participant', 'date',)
+
+for data_stream, data_stream_type in INTRA_TIME_SERIES_TYPES.items():
+    data_stream = data_stream.replace('/', '_')
+    if data_stream_type == '+int':
+        FitbitIntradayRecord.add_to_class(data_stream, models.PositiveIntegerField(blank=True, null=True))
+    elif data_stream_type == 'float':
+        FitbitIntradayRecord.add_to_class(data_stream, models.FloatField(blank=True, null=True))
+    elif data_stream_type == 'json':
+        FitbitIntradayRecord.add_to_class(data_stream, models.TextField(blank=True, null=True))

--- a/database/fitbit_models.py
+++ b/database/fitbit_models.py
@@ -4,8 +4,11 @@ from database.user_models import Participant
 from config.fitbit_constants import TIME_SERIES_TYPES, INTRA_TIME_SERIES_TYPES
 
 
-
 class FitbitCredentials(models.Model):
+    """
+    FitbitCredentials model is used to store Fitbit oAuth2 credentials, linked to a participant.
+    """
+
     participant = models.OneToOneField(Participant, on_delete=models.CASCADE)
     refresh_token = models.TextField()
     access_token = models.TextField()
@@ -22,6 +25,14 @@ class FitbitCredentials(models.Model):
 
 
 class FitbitInfo(models.Model):
+    """
+    FitbitInfo model is used to store data that has no history via Fitbit
+    API e.g. the linked devices of a user. For these data, it is not possible
+    to query the API for their past values. The values in this model represent
+    the state of the information at the given time `date`, in which the data
+    was queried. Considering this, it is important to notice that past information
+    may get lost if the rows are deleted.
+    """
     participant = models.ForeignKey(Participant, on_delete=models.CASCADE)
     date = models.DateTimeField()
 
@@ -31,6 +42,10 @@ class FitbitInfo(models.Model):
 
 
 class FitbitRecord(models.Model):
+    """
+    FitbitInfo model is used to store the daily aggregated data from Fitbit.
+    This information is present in the glanularity of a day.
+    """
     participant = models.ForeignKey(Participant, on_delete=models.CASCADE)
     date = models.DateTimeField()
 
@@ -48,6 +63,11 @@ for data_stream, data_stream_type in TIME_SERIES_TYPES.items():
 
 
 class FitbitIntradayRecord(models.Model):
+    """
+    FitbitIntradayRecord model is used to store the intra-daily aggregated
+    data from Fitbit. This information is present in the glanularity of a
+    minute or a second (for heart rate).
+    """
     participant = models.ForeignKey(Participant, on_delete=models.CASCADE)
     date = models.DateTimeField()
 

--- a/libs/fitbit.py
+++ b/libs/fitbit.py
@@ -21,7 +21,7 @@ from config.settings import (
     IS_SERVERLESS
 )
 
-from database.fitbit_models import (FitbitRecord, FitbitIntradayRecord, FitbitCredentials)
+from database.fitbit_models import (FitbitInfo, FitbitRecord, FitbitIntradayRecord, FitbitCredentials)
 from database.user_models import Participant
 
 from pipeline.boto_helpers import get_boto_client
@@ -45,6 +45,25 @@ SCOPES = [
     'weight'
 ]
 
+def delete_fitbit_records_trigger(credential):
+    events_client = get_boto_client('events', pipeline_region)
+    lambda_client = get_boto_client('lambda', pipeline_region)
+
+    rule_name = FITBIT_RECORDS_LAMBDA_RULE.format(credential.id)
+    permission_name = f"{rule_name}-event"
+
+    events_client.describe_rule(Name=rule_name)
+    targets = events_client.list_targets_by_rule(Rule=rule_name)
+    events_client.remove_targets(
+        Rule=rule_name,
+        Ids=[target['Id'] for target in targets['Targets']],
+    )
+    events_client.delete_rule(Name=rule_name)
+    lambda_client.remove_permission(
+        FunctionName=FITBIT_LAMBDA_ARN,
+        StatementId=permission_name,
+    )
+
 def create_fitbit_records_trigger(credential):
     events_client = get_boto_client('events', pipeline_region)
     lambda_client = get_boto_client('lambda', pipeline_region)
@@ -53,23 +72,13 @@ def create_fitbit_records_trigger(credential):
     permission_name = f"{rule_name}-event"
 
     try:
-        events_client.describe_rule(Name=rule_name)
-        targets = events_client.list_targets_by_rule(Rule=rule_name)
-        events_client.remove_targets(
-            Rule=rule_name,
-            Ids=[target['Id'] for target in targets['Targets']],
-        )
-        events_client.delete_rule(Name=rule_name)
-        lambda_client.remove_permission(
-            FunctionName=FITBIT_LAMBDA_ARN,
-            StatementId=permission_name,
-        )
+        delete_fitbit_records_trigger(credential)
     except Exception as e:
         pass
 
     rule = events_client.put_rule(
         Name=rule_name,
-        ScheduleExpression='rate(4 hours)',
+        ScheduleExpression='cron(0 1 * * ? *)',
         State='ENABLED'
     )
 
@@ -93,84 +102,133 @@ def create_fitbit_records_trigger(credential):
     )
 
 
-def get_fitbit_client(access_token, refresh_token, update_cb=None):
+def get_fitbit_client(credential, update_cb=None):
     return fitbit.Fitbit(
         FITBIT_CLIENT_ID,
         FITBIT_CLIENT_SECRET,
-        access_token=access_token,
-        refresh_token=refresh_token,
+        access_token=credential.access_token,
+        refresh_token=credential.refresh_token,
         refresh_cb=update_cb
     )
 
 
-def get_fitbit_record(access_token, refresh_token, base_date, end_date, update_cb, fetched_dates):
-    res = {}
+def get_fitbit_record(credential, base_date, end_date, update_cb=None, fetched_dates=[], info=True, interday=True, intraday=True):
 
-    client = fitbit.Fitbit(
-        FITBIT_CLIENT_ID,
-        FITBIT_CLIENT_SECRET,
-        access_token=access_token,
-        refresh_token=refresh_token,
-        refresh_cb=update_cb
-    )
+    fitbit_client = get_fitbit_client(credential, update_cb)
 
-    print(f"Fetching singular data")
-    yield 'devices', client.get_devices()
-    yield 'friends', client.get_friends()
-    yield 'friends_leaderboard', client.get_friends_leaderboard()
+    if info:
+        print(f"Fetching singular data")
+
+        info_data = {}
+
+        info_data['devices'] = fitbit_client.get_devices()
+
+        friends = fitbit_client.get_friends()
+        if 'data' in friends:
+            friends = friends['data']
+            for friend in friends:
+                if 'attributes' in friend:
+                    attributes = friend['attributes']
+                    if 'avatar' in attributes:
+                        del friend['attributes']['avatar']
+                    friend.update(attributes)
+                    del friend['attributes']
+        else:
+            friends = []
+        info_data['friends'] = friends
+
+
+        leaderboard = fitbit_client.get_friends_leaderboard()
+        if 'data' in leaderboard:
+            leaderboard = leaderboard['data']
+            for friend in leaderboard:
+                if 'relationships' in friend:
+                    del friend['relationships']
+                    
+                if 'attributes' in friend:
+                    attributes = friend['attributes']
+                    friend.update(attributes)
+                    del friend['attributes']
+        else:
+            leaderboard = []
+        info_data['friends_leaderboard'] = leaderboard
+
+        yield 'info', info_data
+        del info_data
 
     BMR = {}
 
-    res = defaultdict(dict)
-    for k, type_str in TIME_SERIES_TYPES.items():
-        print(f"Fetching {k} time series")
+    if interday:
 
-        record = client.time_series(k, base_date=base_date, end_date=end_date)
-        data = record[k.replace('/', '-')]
-        for dp in data:
-            date = dp['dateTime']
-            if date in fetched_dates:
-                continue
-            res[date][k.replace('/', '_')] = dp['value']
+        res = defaultdict(dict)
+        for data_stream, _ in TIME_SERIES_TYPES.items():
+            print(f"Fetching {data_stream} time series")
 
-            if k == 'activities/caloriesBMR':
-                BMR[date] = (float(dp['value']) / 24. / 60.) + 0.005 # corretion for daily spec
+            record = fitbit_client.time_series(
+                data_stream,
+                base_date=base_date,
+                end_date=end_date
+            )
+            data = record[data_stream.replace('/', '-')]
+            for dp in data:
+                if data_stream == 'sleep':
+                    date = dp['dateOfSleep']
+                    if date in fetched_dates:
+                        continue
+                    res[date][data_stream] = res[date].get(data_stream, []) + [dp]
+                else:
+                    date = dp['dateTime']
+                    if date in fetched_dates:
+                        continue
+                    res[date][data_stream.replace('/', '_')] = dp['value']
 
-    yield 'time_series', res
+                if data_stream == 'activities/caloriesBMR':
+                    BMR[date] = (float(dp['value']) / 24. / 60.) + 0.005 # corretion for daily spec
 
+        yield 'time_series', res
 
-    delta = timedelta(days=1)
-    intra_date = datetime.strptime(base_date, '%Y-%m-%d').date()
-    end_date = datetime.strptime(end_date, '%Y-%m-%d').date()
-    while intra_date <= end_date:
-        intra_date_fmt = intra_date.strftime("%Y-%m-%d")
+    if intraday:
 
-        if intra_date_fmt not in fetched_dates:
-            print(f"Day: {intra_date_fmt}")
+        delta = timedelta(days=1)
+        intra_date = datetime.strptime(base_date, '%Y-%m-%d').date()
+        end_date = datetime.strptime(end_date, '%Y-%m-%d').date()
+        while intra_date <= end_date:
+            intra_date_fmt = intra_date.strftime("%Y-%m-%d")
 
-            res = defaultdict(dict)
-            for k, type_str in INTRA_TIME_SERIES_TYPES.items():
+            if intra_date_fmt not in fetched_dates:
+                print(f"Day: {intra_date_fmt}")
 
-                print(f"- fetching {k} intra-day time series")
+                res = defaultdict(dict)
+                for data_stream, _ in INTRA_TIME_SERIES_TYPES.items():
 
-                record = client.intraday_time_series(k, base_date=intra_date_fmt, detail_level='1min')
+                    if 'activities/heart' != data_stream:
+                        continue
 
-                k_db = k.replace('/', '_')
-                k_api = k.replace('/', '-')
-                data = record[f"{k_api}-intraday"]
-                for metric in data['dataset']:
+                    print(f"- fetching {data_stream} intra-day time series")
 
-                    threshold = 0.0
-                    if k == 'activities/calories':
-                        threshold = BMR.get(intra_date, 0.0)
+                    record = fitbit_client.intraday_time_series(
+                        data_stream,
+                        base_date=intra_date_fmt,
+                        detail_level='1min'
+                    )
 
-                    if threshold > metric['value']:
-                        metric_datetime = f"{intra_date} {metric['time']}"
-                        res[metric_datetime][k_db] = metric['value']
+                    data_stream_db = data_stream.replace('/', '_')
+                    data_stream_api = data_stream.replace('/', '-')
+                    data = record[f"{data_stream_api}-intraday"]
+                    print(data)
+                    for metric in data['dataset']:
 
-            yield 'intra_time_series', res
+                        threshold = 0.0
+                        if data_stream == 'activities/calories':
+                            threshold = BMR.get(intra_date, 0.0)
 
-        intra_date += delta
+                        if threshold > metric['value']:
+                            metric_datetime = f"{intra_date} {metric['time']}"
+                            res[metric_datetime][data_stream_db] = metric['value']
+
+                yield 'intra_time_series', res
+
+            intra_date += delta
 
 
 def do_process_fitbit_records_lambda_handler(event, context):
@@ -180,23 +238,19 @@ def do_process_fitbit_records_lambda_handler(event, context):
     credential_id = event['credential']
     credential = FitbitCredentials.objects.get(pk=credential_id)
 
-    user = credential.user
+    participant = credential.participant
     access_token = credential.access_token
     refresh_token = credential.refresh_token
 
     initial_date = '2020-05-01'
     yesterday_date = (datetime.utcnow() - timedelta(days=1)).strftime('%Y-%m-%d')
-    today_date = datetime.utcnow().strftime('%Y-%m-%d')
-    tomorrow_date = (datetime.utcnow() + timedelta(days=1)).strftime('%Y-%m-%d')
 
-    print(f"Fetching dates for user {user.patient_id}")
+    print(f"Fetching dates for participant {participant.patient_id}")
 
     fetched_dates = set([
-        d['last_updated'].strftime('%Y-%m-%d')
-        for d in FitbitRecord.objects.filter(user=user).values('last_updated').values('last_updated')
+        record['date'].strftime('%Y-%m-%d')
+        for record in FitbitRecord.objects.filter(participant=participant).values('date').values('date')
     ])
-
-    fetched_dates -= set([yesterday_date, today_date])
 
     def update_token(token_dict):
         print("Updating token")
@@ -204,60 +258,40 @@ def do_process_fitbit_records_lambda_handler(event, context):
         credential.refresh_token = token_dict['refresh_token']
         credential.save()
 
-    fixed_info = {}
-
     try:
-        # There is a max time range
-        for restype, res in get_fitbit_record(
-            access_token, refresh_token,
-            initial_date, today_date,
-            update_token, fetched_dates
+        for resource_type, resource in get_fitbit_record(
+            credential,
+            initial_date, yesterday_date,
+            update_token, fetched_dates,
         ):
-            if restype in ['devices', 'friends', 'friends_leaderboard']:
-                fixed_info[restype] = res
+            if resource_type == 'info':
+                FitbitInfo(
+                    participant=participant,
+                    date=datetime.utcnow(),
+                    **resource
+                ).save()
 
-            if restype == 'time_series':
+            if resource_type == 'time_series':
                 records = []
-                has_yesterday = False
-                has_today = False
-                for time, data in res.items():
-
-                    if time == today_date:
-                        has_today = True
-                    if time == yesterday_date:
-                        has_yesterday = True
-
+                for time, data in resource.items():
                     records += [
-                        FitbitRecord(user=user, last_updated=time, **fixed_info, **data)
+                        FitbitRecord(
+                            participant=participant,
+                            date=time, **data
+                        )
                     ]
-
-                if has_yesterday:
-                    FitbitRecord.objects.filter(last_updated=yesterday_date).delete()
-                if has_today:
-                    FitbitRecord.objects.filter(last_updated=today_date).delete()
-
                 FitbitRecord.objects.bulk_create(records)
 
-            if restype == 'intra_time_series':
+            if resource_type == 'intra_time_series':
                 records = []
-                has_yesterday = False
-                has_today = False
-                for time, data in res.items():
-
-                    if time[0:10] == today_date:
-                        has_today = True
-                    if time[0:10] == yesterday_date:
-                        has_yesterday = True
-
+                for time, data in resource.items():
                     records += [
-                        FitbitIntradayRecord(user=user, last_updated=time, **data)
+                        FitbitIntradayRecord(
+                            participant=participant,
+                            date=time,
+                            **data
+                        )
                     ]
-
-                if has_yesterday:
-                    FitbitIntradayRecord.objects.filter(last_updated__range=[yesterday_date, today_date]).delete()
-                if has_today:
-                    FitbitIntradayRecord.objects.filter(last_updated__range=[today_date, tomorrow_date]).delete()
-
                 FitbitIntradayRecord.objects.bulk_create(records)
 
     except Exception as e:
@@ -327,14 +361,20 @@ def authorize(code, state):
         access_token = resp['access_token']
         refresh_token = resp['refresh_token']
 
-        records = FitbitCredentials.objects.filter(user__patient_id__exact=patient_id)
+        records = FitbitCredentials.objects.filter(
+            participant__patient_id__exact=patient_id
+        )
         if records.exists():
-            record: FitbitCredentials = records.get()
+            record = records.get()
             record.access_token = access_token
             record.refresh_token = refresh_token
             record.save()
         else:
-            record = FitbitCredentials(access_token=access_token, refresh_token=refresh_token, user=participant)
+            record = FitbitCredentials(
+                access_token=access_token,
+                refresh_token=refresh_token,
+                participant=participant
+            )
             record.save()
     except Exception as e:
         traceback.print_exc()

--- a/libs/fitbit.py
+++ b/libs/fitbit.py
@@ -7,8 +7,9 @@ from datetime import datetime, date, timedelta
 import requests
 import traceback
 
+import boto3
 import fitbit
-from flask_jwt_extended import (create_access_token, decode_token, jwt_required)
+from flask_jwt_extended import (create_access_token, decode_token)
 
 # noinspection PyUnresolvedReferences
 from config import load_django
@@ -23,8 +24,6 @@ from config.settings import (
 
 from database.fitbit_models import (FitbitInfo, FitbitRecord, FitbitIntradayRecord, FitbitCredentials)
 from database.user_models import Participant
-
-from pipeline.boto_helpers import get_boto_client
 
 
 pipeline_region = os.getenv("pipeline_region", None)
@@ -46,8 +45,9 @@ SCOPES = [
 ]
 
 def delete_fitbit_records_trigger(credential):
-    events_client = get_boto_client('events', pipeline_region)
-    lambda_client = get_boto_client('lambda', pipeline_region)
+    events_client = boto3.client('events', region_name=pipeline_region)
+    lambda_client = boto3.client('lambda', region_name=pipeline_region)
+
 
     rule_name = FITBIT_RECORDS_LAMBDA_RULE.format(credential.id)
     permission_name = f"{rule_name}-event"
@@ -65,8 +65,8 @@ def delete_fitbit_records_trigger(credential):
     )
 
 def create_fitbit_records_trigger(credential):
-    events_client = get_boto_client('events', pipeline_region)
-    lambda_client = get_boto_client('lambda', pipeline_region)
+    events_client = boto3.client('events', region_name=pipeline_region)
+    lambda_client = boto3.client('lambda', region_name=pipeline_region)
 
     rule_name = FITBIT_RECORDS_LAMBDA_RULE.format(credential.id)
     permission_name = f"{rule_name}-event"

--- a/libs/fitbit.py
+++ b/libs/fitbit.py
@@ -328,6 +328,18 @@ def do_process_fitbit_records_lambda_handler(event, context):
         }
 
 
+def trigger_process_fitbit_records(credential):
+    try:
+        lambda_client = boto3.client('lambda', region_name=pipeline_region)
+        lambda_client.invoke(
+            FunctionName=FITBIT_LAMBDA_ARN,
+            InvocationType='Event',
+            Payload=json.dumps({"credential": str(credential.id)})
+        )
+    except:
+        traceback.print_exc()
+
+
 def recreate_fitbit_records_trigger():
     for credential in FitbitCredentials.objects.all():
         create_fitbit_records_trigger(credential)
@@ -399,16 +411,6 @@ def authorize(code, state):
     except Exception as e:
         traceback.print_exc()
         raise Exception('INTERNAL_ERROR')
-
-    # try:
-    #     client = get_boto_client('lambda', pipeline_region)
-    #     client.invoke(
-    #         FunctionName=FITBIT_LAMBDA_ARN,
-    #         InvocationType='Event',
-    #         Payload=json.dumps({"credential": str(record.id)})
-    #     )
-    # except:
-    #     traceback.print_exc()
 
     try:
         create_fitbit_records_trigger(record)

--- a/scripts/fitbit_utils.py
+++ b/scripts/fitbit_utils.py
@@ -18,7 +18,8 @@ from database.fitbit_models import (
 from libs.fitbit import (
     create_fitbit_records_trigger,
     delete_fitbit_records_trigger,
-    do_process_fitbit_records_lambda_handler
+    do_process_fitbit_records_lambda_handler,
+    trigger_process_fitbit_records
 )
 
 def confirm(message):
@@ -83,6 +84,12 @@ if __name__ == "__main__":
             event={"credential": credential.id},
             context=None
         )
+
+    elif args.action == 'sync_lambda':
+
+        print(f"Invoking Fitbit lambda for '{participant.patient_id}'...")
+
+        trigger_process_fitbit_records(credential)
 
     elif args.action == 'delete_credential':
         if confirm(f"Do you confirm you want to delete the Fitbit credential for '{participant.patient_id}'?"):

--- a/scripts/fitbit_utils.py
+++ b/scripts/fitbit_utils.py
@@ -55,13 +55,11 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.action == 'list':
-
         print(f"Participant patient_ids with Fitbit integration:")
-
-        print(FitbitCredentials.objects.all().values('participant').values('participant'))
+        for participant in FitbitCredentials.objects.all().values('participant').values('participant'):
+            print('- ' + Participant.objects.get(pk=participant['participant']).patient_id)
 
         sys.exit(0)
-
 
 
     if args.participant_id and args.patient_id:

--- a/scripts/fitbit_utils.py
+++ b/scripts/fitbit_utils.py
@@ -1,26 +1,107 @@
+from os.path import abspath as _abspath
+from sys import path as _path
+_one_folder_up = _abspath(__file__).rsplit('/', 2)[0]
+_path.insert(1, _one_folder_up)
+
 import argparse
 import os
+import sys
 
 import config.load_django
-from database.fitbit_models import FitbitCredentials
 from database.user_models import Participant
-from libs.fitbit import (delete_fitbit_records_trigger, get_fitbit_client,
-                         get_fitbit_record)
+from database.fitbit_models import (
+    FitbitCredentials,
+    FitbitInfo,
+    FitbitRecord,
+    FitbitIntradayRecord
+)
+from libs.fitbit import (
+    create_fitbit_records_trigger,
+    delete_fitbit_records_trigger,
+    do_process_fitbit_records_lambda_handler
+)
+
+def confirm(message):
+    answer = ""
+    while answer not in ["Y", "n"]:
+        answer = input(f"{message} [Y/n]")
+    return answer == "Y"
 
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Beiwe Fitbit tool")
 
     parser.add_argument(
-        'participant_id',
+        '--participant_id',
         help='Participant id number (integer greater than 0).',
         type=int
     )
 
     parser.add_argument(
-        'patient_id',
+        '--patient_id',
         help='Patient id number (string with 8 characters).',
         type=str
     )
 
+    parser.add_argument('action', type=str, choices=[
+        'list',
+        'sync',
+        'delete_credential',
+        'wipe_credential',
+        'recreate_trigger',
+        'delete_trigger'
+    ])
+
     args = parser.parse_args()
+
+    if args.action == 'list':
+
+        print(f"Participant patient_ids with Fitbit integration:")
+
+        print(FitbitCredentials.objects.all().values('participant').values('participant'))
+
+        sys.exit(0)
+
+
+
+    if args.participant_id and args.patient_id:
+        print("Please provide just one of them: participant_id or patient_id")
+
+    if args.participant_id:
+        participant = Participant.objects.filter(id=args.participant_id).get()
+    if args.patient_id:
+        participant = Participant.objects.filter(patient_id=args.patient_id).get()
+
+    try:
+        credential = FitbitCredentials.objects.filter(participant=participant).get()
+    except:
+        print(f"The participant '{participant.patient_id}' does not have a Fitbit credential")
+
+    if args.action == 'sync':
+
+        print(f"Fetching Fitbit data from '{participant.patient_id}'...")
+
+        do_process_fitbit_records_lambda_handler(
+            event={"credential": credential.id},
+            context=None
+        )
+
+    elif args.action == 'delete_credential':
+        if confirm(f"Do you confirm you want to delete the Fitbit credential for '{participant.patient_id}'?"):
+            credential.delete()
+
+    elif args.action == 'wipe_credential':
+        if confirm(f"Do you confirm you want to wipe the Fitbit credential for '{participant.patient_id}'? "
+                    "It will erase all the recorded data, except the credential."):
+
+            FitbitInfo.objects.filter(participant=participant)
+            FitbitRecord.objects.filter(participant=participant)
+            FitbitIntradayRecord.objects.filter(participant=participant)
+
+    elif args.action == 'recreate_trigger':
+        create_fitbit_records_trigger(credential)
+
+    elif args.action == 'delete_trigger':
+        delete_fitbit_records_trigger(credential)
+
+

--- a/scripts/fitbit_utils.py
+++ b/scripts/fitbit_utils.py
@@ -1,0 +1,26 @@
+import argparse
+import os
+
+import config.load_django
+from database.fitbit_models import FitbitCredentials
+from database.user_models import Participant
+from libs.fitbit import (delete_fitbit_records_trigger, get_fitbit_client,
+                         get_fitbit_record)
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="Beiwe Fitbit tool")
+
+    parser.add_argument(
+        'participant_id',
+        help='Participant id number (integer greater than 0).',
+        type=int
+    )
+
+    parser.add_argument(
+        'patient_id',
+        help='Patient id number (string with 8 characters).',
+        type=str
+    )
+
+    args = parser.parse_args()


### PR DESCRIPTION
Models:
- Change name of fields to something more mnemonic
- Add a new model to store 'atemporal' data (such as devices and friends). Refer to model docstring for a full explanation
- Delete Lambda functions when deleting a credential
- Add unique constraints

Data fetching process:
- Get data until the last day. Do not get today's data
- Replace cronjob from every 4h to every 1AM
- Preprocess friends and leadership data: simplify their structure and remove avatar URLs
- Fix the bug for sleep data

Fitbit Utils:
Now there is a script to help to manage the credential and testing the process. You can:
- List participants with Fitbit
- Delete a credential
- Wipe out the data from a credential
- (Re)create a lambda trigger for a credential
- Delete a lambda trigger for a credential
- Fetch Fitbit data for a credential, using lambda or running it locally

Some questions:

- Should I re-enable the initial lambda invocation when the user authorizes? The cronjob in the format of a cron job does not trigger the lambda when scheduled. I believe not, but let me know. 

- It seems like the dates are not in UTC, but in the user timezone. Should I convert it to UTC, or we consider that the dates on the database are naive? In any case, we might want to run the cronjob later (e.g noon) to consider that the day just ended in the last timezone? Maybe, not sure.

(btw, disregard the commits under your name @ccraddock , it was because of the .gitconfig in the development server AMI)

I've tested all the pieces through the utils, but since it has migrations to be done, I did not do a full test on the production base. The migration would break the Fitbit lambda, and I am not 100% confident in deploying a lambda function yet (may we go over this again, please?). By now, I can disable the triggers and do the migration, just let me know if it is ok for you.
And I am also not sure if the authorization form for Fitbit is out for the participants, so I don't want to break that either.